### PR TITLE
Fix main language not translated in xlsx

### DIFF
--- a/classes/Translations/TranslateInheritance.php
+++ b/classes/Translations/TranslateInheritance.php
@@ -82,7 +82,7 @@ class TranslateInheritance
         ];
         foreach ($filesByPriority as $file) {
             if (file_exists($file)) {
-                include_once $file;
+                require $file;
             }
         }
 


### PR DESCRIPTION
The issue was caused by `include_once` having no effect on the main language as the translation file had been already loaded in memory.