### PR TITLE
Improve regex to catch only the first param of this->l()

### DIFF
--- a/classes/Translations/GetTranslations.php
+++ b/classes/Translations/GetTranslations.php
@@ -25,8 +25,8 @@ use PrestaShop\Module\PsTranslateYourModule\File\CheckFile;
 class GetTranslations
 {
     const REGEX_TPL = "/{l s=['\"]((?=\S)[^}]+)['\"] mod='[a-z_]+'.*}/U";
-    const REGEX_CLASS = "/this->l\('((?=\S)[^)]+)'\)/";
-    const REGEX_ADMIN_CLASS = "/this->module->l\('((?=\S)[^)]+)'\)/";
+    const REGEX_CLASS = "/this->l\('((?=\S)[^)']+)'/";
+    const REGEX_ADMIN_CLASS = "/this->module->l\('((?=\S)[^)']+)'[),]/";
 
     protected $moduleName;
     protected $modulePath;


### PR DESCRIPTION
This PR improve the regex to avoid translations being wrong:

```
Your card cannot be used to pay in this currency, please try another payment method.', 'translations
--
Your card cannot be used to pay in our country, please try another payment method.', 'translations
This payment method declined transaction, please try another.', 'translations
You have exceeded the maximum number of payment attempts.', 'translations
Your PayPal account is locked or closed, please try another.', 'translations
You are not allowed to pay with this PayPal account, please try another.', 'translations
You are not allowed to pay with this payment method, please try another.', 'translations
Your country is not supported by this payment method, please try to select another.', 'translations
The transaction failed. Please try a different payment method.', 'translations
The transaction was blocked by Fraud Protection settings.', 'translations
The transaction was refused.', 'translations
This payment method seems not working currently, please try another.', 'translations
Please try a different payment method or try again later.', 'translations
You have selected your [PAYPAL_ACCOUNT] PayPal account to proceed to the payment.', 'translations

```