### PR TITLE
Update export, import & compat' with PHP 7.3

### DIFF
--- a/classes/Import.php
+++ b/classes/Import.php
@@ -24,11 +24,13 @@ use PrestaShop\Module\PsTranslateYourModule\File\WriteLanguageFile;
 use PrestaShop\Module\PsTranslateYourModule\Translations\TranslationsCode;
 
 if (!function_exists('array_key_first')) {
-    function array_key_first(array $arr) {
-        foreach($arr as $key => $unused) {
+    function array_key_first(array $arr)
+    {
+        foreach ($arr as $key => $unused) {
             return $key;
         }
-        return NULL;
+
+        return null;
     }
 }
 
@@ -140,9 +142,13 @@ class Import
                     continue;
                 }
 
+                if (empty($sentence)) {
+                    continue;
+                }
+
                 $sentenceCode = $translationsCode->getOneTranslationCode($translations['filesname'][$key], $translations['en'][$key], $moduleName);
                 // replace : ' to \'   but not   \' to \\'
-                $sentenceToWrite = preg_replace('/(?<!\\\\)\'/', '\\\'', $sentence);
+                $sentenceToWrite = preg_replace('/(?<!\\\\)\'/', '\\\'', stripcslashes($sentence));
                 $translationsToWriteInFile[$lang] .= self::CODE_BEGINS . $sentenceCode . self::CODE_ENDS . self::SENTENCE_BEGINS . $sentenceToWrite . self::SENTENCE_ENDS;
             }
         }

--- a/classes/Import.php
+++ b/classes/Import.php
@@ -23,6 +23,15 @@ namespace PrestaShop\Module\PsTranslateYourModule;
 use PrestaShop\Module\PsTranslateYourModule\File\WriteLanguageFile;
 use PrestaShop\Module\PsTranslateYourModule\Translations\TranslationsCode;
 
+if (!function_exists('array_key_first')) {
+    function array_key_first(array $arr) {
+        foreach($arr as $key => $unused) {
+            return $key;
+        }
+        return NULL;
+    }
+}
+
 class Import
 {
     const TRANSLATION_FILE_BEGINS = "<?php\nglobal \$_MODULE;\n\$_MODULE = array();\n";

--- a/classes/Translations/GetTranslations.php
+++ b/classes/Translations/GetTranslations.php
@@ -25,8 +25,8 @@ use PrestaShop\Module\PsTranslateYourModule\File\CheckFile;
 class GetTranslations
 {
     const REGEX_TPL = "/{l s=['\"]((?=\S)[^}]+)['\"] mod='[a-z_]+'.*}/U";
-    const REGEX_CLASS = "/this->l\('((?=\S)[^)']+)'/";
-    const REGEX_ADMIN_CLASS = "/this->module->l\('((?=\S)[^)']+)'[),]/";
+    const REGEX_CLASS = "/this->l\(\s*[\"'](.+?)[\"'](?:,\s*'(.+?)'\s*)?\)/m";
+    const REGEX_ADMIN_CLASS = "/this->module->l\(\s*[\"'](.+?)[\"'](?:,\s*'(.+?)'\s*)?\)/m";
 
     protected $moduleName;
     protected $modulePath;

--- a/classes/Translations/TranslationsCode.php
+++ b/classes/Translations/TranslationsCode.php
@@ -52,6 +52,7 @@ class TranslationsCode
      */
     public function getOneTranslationCode($domain, $sentence, $moduleName)
     {
+        $sentence = stripcslashes($sentence);
         $escapedSentence = preg_replace("/\\\*'/", "\'", $sentence);
         $translationCode = '<{' . $moduleName . '}prestashop>' . strtolower($domain) . '_' . md5($escapedSentence);
 

--- a/controllers/admin/AdminDownloadZipController.php
+++ b/controllers/admin/AdminDownloadZipController.php
@@ -52,6 +52,6 @@ class AdminDownloadZipController extends ModuleAdminController
 
         $getZip->downloadZip();
 
-        die();
+        exit();
     }
 }

--- a/controllers/admin/AdminExportTranslationsController.php
+++ b/controllers/admin/AdminExportTranslationsController.php
@@ -66,7 +66,7 @@ class AdminExportTranslationsController extends ModuleAdminController
 
         (new Export($moduleName, $formatedTranslatedArray, $exportType))->xlsx($languages);
 
-        die();
+        exit();
     }
 
     /**


### PR DESCRIPTION
* Files could not be imported on PHP 7.2 and below
* Avoid empty strings in translation files
* Improve detection of translations with double quotes
* Allow the use of `\n` in the english strings